### PR TITLE
Remove Rating from PlexResponse.Metadata struct

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -63,7 +63,6 @@ type Metadata struct {
 	Tagline               string
 	Index                 int
 	ParentIndex           int
-	Rating                float32
 	RatingCount           int
 	AudienceRating        float32
 	ViewOffset            int


### PR DESCRIPTION
FYI, the data structure that causes issues looks like this:

    "Rating":
    [
        {
            "image": "themoviedb://image.rating",
            "value": 6.5,
            "type": "audience"
        }
    ],

So in javascript terms Plex webhooks API sends a type that looks like this `number | { image: string, value: number, type: string }[]`. Which is just silly.

I don't know how to express that in go, so I'm just removing it since we don't need it for Plaxt.